### PR TITLE
Remove parser from mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,6 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     'astroid',
-    'langkit.*',
-    'librflxlang',
     'pylint.*',
     'ruamel',
     'setuptools.*',


### PR DESCRIPTION
In preparation of Componolit/RecordFlux-parser#11 and Componolit/RecordFlux#804