### PR TITLE
Include langkit in mypy overrides again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     'astroid',
+    'langkit.*',
     'pylint.*',
     'ruamel',
     'setuptools.*',


### PR DESCRIPTION
We need to include langkit into the mypy overrides again as it does *not* have type annotations and we want to check our scripts in the parser with mypy. I didn't realize that issue (probably due to mypy caching).